### PR TITLE
fix(main): fix footer overlap

### DIFF
--- a/components/common/BaseLayout/index.tsx
+++ b/components/common/BaseLayout/index.tsx
@@ -34,7 +34,7 @@ function BaseLayout({ children }: any): React.ReactElement {
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
       </Head>
       <Top user={user} />
-      <main className="h-screen"> {children} </main>
+      <main className="min-h-screen"> {children} </main>
       <Bottom user={user} />
     </div>
   )


### PR DESCRIPTION
keeping the **main** element height as 100vh , makes the elements after It to overlap with other elements.
In this case ,
**main** element is followed by **footer** element.
If the content inside *main* is more than 100vh, the content after 100vh inside **main** and **footer** will overlap.