### PR TITLE
feat(finance): fixing broken scenarios

### DIFF
--- a/components/finance/ExpensePanelDetails/index.tsx
+++ b/components/finance/ExpensePanelDetails/index.tsx
@@ -23,7 +23,6 @@ export default function ExpensePanelDetails({
   updateAmountSum,
   currencyList,
   defaultCurrency,
-  panelPosition,
 }: any) {
   const classes = useStyles()
   const handleTotalValues = (valuen: any) => () => {
@@ -85,8 +84,8 @@ export default function ExpensePanelDetails({
   }
 
   return (
-    <div className={`rounded absolute z-10 ${panelPosition.left} ${panelPosition.top}`}>
-      <div className="bg-secondary inline-block rounded">
+    <div className="rounded absolute block w-2/4 flex">
+      <div className="bg-secondary block rounded">
         <ExpensePanelRows
           totalValues={totalValues}
           handleChange={handleChange}

--- a/components/finance/FinanceCategories/index.tsx
+++ b/components/finance/FinanceCategories/index.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable jsx-a11y/mouse-events-have-key-events */
 import { gql, useQuery } from '@apollo/client'
-import React, { useState } from 'react'
-import { useToggle } from 'react-use'
+import React from 'react'
 
 import Loader from '../../common/Loader'
-import ExpensePanelDetails from '../ExpensePanelDetails'
 import FinanceCategoryList from '../FinanceCategoryList'
 import FinanceSpreadSheet from '../FinanceSpreadSheet'
 
@@ -27,27 +25,7 @@ const FinanceCategories = ({ columns, activeCell, setActiveCell }: financeCatego
       }
     }
   `
-  const leftMargin = 384
-  const topMargin = 138
-  const [panelPosition, setPanelPosition] = useState({
-    top: `${topMargin}px`,
-    left: `${leftMargin}px`,
-  })
-  const [isOn, toggleIsOn] = useToggle(false)
   const { loading, error, data } = useQuery(getCategories())
-  const defaultCurrency = '$'
-  const currencyList = ['INR', '$', 'YUH']
-  const [totalValues, setTotalValues] = useState({
-    rows: [
-      {
-        currency: defaultCurrency,
-        amount: 0,
-        comment: '',
-        tags: '',
-        person: '',
-      },
-    ],
-  })
   if (loading || error)
     return (
       <div>
@@ -56,16 +34,6 @@ const FinanceCategories = ({ columns, activeCell, setActiveCell }: financeCatego
     )
   const [activeRow, activeColumn] = activeCell
   const { workItems } = data.finance
-
-  const panelSize = 880
-
-  const togglePanel = (row: any, col: any) => {
-    toggleIsOn()
-    setPanelPosition({
-      top: `top-[${topMargin + row * 49}px]`,
-      left: `left-[${leftMargin + Math.min(((columns - 1) * 160) % panelSize, col * 160)}px]`,
-    })
-  }
 
   return (
     <div className="flex flex-col mt-0">
@@ -81,23 +49,10 @@ const FinanceCategories = ({ columns, activeCell, setActiveCell }: financeCatego
               rowIndex={rowIndex}
               activeCell={activeCell}
               setActiveCell={setActiveCell}
-              togglePanel={togglePanel}
             />
           </li>
         ))}
       </ul>
-      {isOn ? (
-        <div>
-          <ExpensePanelDetails
-            toggleIsOn={toggleIsOn}
-            totalValues={totalValues}
-            setTotalValues={setTotalValues}
-            currencyList={currencyList}
-            defaultCurrency={defaultCurrency}
-            panelPosition={panelPosition}
-          />
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/components/finance/FinanceSpreadSheet/index.tsx
+++ b/components/finance/FinanceSpreadSheet/index.tsx
@@ -1,15 +1,27 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from 'react'
+import { useToggle } from 'react-use'
 
-const FinanceSpreadSheet = ({ columns, rowIndex, activeCell, setActiveCell, togglePanel }: any) => {
+import IncomeExpenseBrick from '../IncomeExpenseBrick'
+
+const FinanceSpreadSheet = ({ columns, rowIndex, activeCell, setActiveCell }: any) => {
   const isEqual = (a: any, b: any): Boolean => a <= b && a >= b
   const [activeRow, activeColumn] = activeCell
+  const map1 = new Map() // keeps track of ceslls for which button would be visible
+
+  map1.set('10', 1)
+  map1.set('12', 1)
+  map1.set('13', 1)
+  map1.set('14', 1)
+  map1.set('16', 1)
 
   return (
     <>
       {Array.from({ length: columns }, (_, columnIndex) => {
         const cellIndex = [rowIndex, columnIndex]
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        const [isOn, toggleIsOn] = useToggle(true)
 
         let borderStyles = ''
         if (isEqual(cellIndex, activeCell)) {
@@ -25,8 +37,12 @@ const FinanceSpreadSheet = ({ columns, rowIndex, activeCell, setActiveCell, togg
             key={`${rowIndex}${columnIndex}`}
             className={`w-40 p-5 border-box border-solid ${borderStyles} `}
             onMouseOver={() => setActiveCell(cellIndex)}
-            onClick={() => togglePanel(rowIndex, columnIndex)}
-          />
+            onClick={toggleIsOn}
+          >
+            {map1.get(`${rowIndex}${columnIndex}`) !== undefined && isOn ? (
+              <IncomeExpenseBrick keyValue={`${rowIndex}${columnIndex}`} />
+            ) : null}
+          </div>
         )
       })}
     </>

--- a/components/finance/IncomeExpenseBrick/index.tsx
+++ b/components/finance/IncomeExpenseBrick/index.tsx
@@ -18,9 +18,9 @@ const useStyles = makeStyles(() =>
   })
 )
 
-export default function IncomeExpenseBrick() {
+export default function IncomeExpenseBrick({ keyValue }: any) {
   const classes = useStyles()
-  const [isOn, toggleIsOn] = useToggle(false)
+  const [isOn, toggleIsOn] = useToggle(true)
   const [amount, updateAmountSum] = useState(0.0)
   const currencyList = ['INR', '$', 'YUH']
   const defaultCurrency = '$'
@@ -38,7 +38,7 @@ export default function IncomeExpenseBrick() {
 
   return (
     <ClientSideRendering>
-      <div className="ml-24">
+      <div className="ml-24" key={keyValue}>
         <Button
           size="large"
           type="submit"


### PR DESCRIPTION
Fixes #<issue no>
Screenshot: (if applicable):  
Description of the change:

The IncomeExpenseGroup should be one per cell and hence the ExpenseRowDetails would also be those many. IncomeExpenseGroup and ExpenseRowDetails should never be put separately rather should be used together always. I have added a template on how to use have the flow.
Things needed are:
1. Add button inside the cell
2. Have way to toggle button and toggle cell independently, right now it's messed up


The images state potential places where buttons would be there for debugging.

![image](https://user-images.githubusercontent.com/7633366/125855254-053d2d38-3b4f-4f13-965f-633d892256df.png)


Old state what issues were happening:
1. The same expenserow details was shared by every cell
2. The expense row cell shows at the bottom which is odd
3. Functionality of item addition etc broke 
4. More issues:
![image](https://user-images.githubusercontent.com/7633366/125856232-d5a26a12-ae2e-4798-9e2f-de9d143a15f4.png)
![image](https://user-images.githubusercontent.com/7633366/125856286-b8bef7f2-e2ba-4027-89f2-119ba7669302.png)

