### PR TITLE
Fix double rendering of header, footer in terms and privacy page,  create a plan page

### DIFF
--- a/components/common/SideBar/index.tsx
+++ b/components/common/SideBar/index.tsx
@@ -82,7 +82,7 @@ export default function MiniDrawer() {
             </ListItem>
           </Link>
 
-          <Link href="/finance" passHref>
+          <Link href="/finance/actuals" passHref>
             <ListItem button key="Manage Finances">
               <ListItemIcon>
                 <InboxIcon />

--- a/components/finance/FinanceSwitch/index.tsx
+++ b/components/finance/FinanceSwitch/index.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import Link from 'next/link'
+import React from 'react'
+
+const FinanceSwitch = ({ actualOrPlan }: any) => (
+  <div className="flex justify-center items-center">
+    <div className="flex border-2 border-solid border-gray-200 rounded-full">
+      <Link href="./actuals">
+        <a className={`py-2 px-4 rounded-l-full ${actualOrPlan === 'Actual' && 'bg-primary text-white'}`}>Actual</a>
+      </Link>
+      <Link href="./plan">
+        <a className={`py-2 px-4 rounded-r-full ${actualOrPlan === 'Plan' && 'bg-primary text-white'}`}>Plan</a>
+      </Link>
+    </div>
+  </div>
+)
+
+export default FinanceSwitch

--- a/pages/finance/actuals.tsx
+++ b/pages/finance/actuals.tsx
@@ -1,11 +1,12 @@
 import { Button, makeStyles } from '@material-ui/core'
 import React, { useState } from 'react'
 
-import BaseLayout from '../components/common/BaseLayout'
-import FinanceCategories from '../components/finance/FinanceCategories'
-import FinanceDateHeader from '../components/finance/FinanceDateHeader'
-import IncomeExpenseBrick from '../components/finance/IncomeExpenseBrick'
-import { dateAfterDays, dateBeforeDays, startDateAfterMonths, startDateBeforeMonths } from '../lib/date-helper'
+import BaseLayout from '../../components/common/BaseLayout'
+import FinanceCategories from '../../components/finance/FinanceCategories'
+import FinanceDateHeader from '../../components/finance/FinanceDateHeader'
+import FinanceSwitch from '../../components/finance/FinanceSwitch'
+import IncomeExpenseBrick from '../../components/finance/IncomeExpenseBrick'
+import { dateAfterDays, dateBeforeDays, startDateAfterMonths, startDateBeforeMonths } from '../../lib/date-helper'
 
 const useStyles = makeStyles({
   button: {
@@ -33,7 +34,7 @@ function Finance() {
       <IncomeExpenseBrick />
       <div>
         <div className="grid grid-cols-financeHeader h-16">
-          <div />
+          <FinanceSwitch actualOrPlan="Actual" />
           <FinanceDateHeader startDate={values.startDate} endDate={values.endDate} activeColumn={activeCell[1]} />
         </div>
         <div className="flex">

--- a/pages/finance/plan.tsx
+++ b/pages/finance/plan.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import FinanceSwitch from '../../components/finance/FinanceSwitch'
+
+function Plan() {
+  return (
+    <div className="grid grid-cols-financeHeader h-16">
+      <FinanceSwitch actualOrPlan="Plan" />
+    </div>
+  )
+}
+
+export default Plan

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,9 +1,6 @@
 import Head from 'next/head'
 import React from 'react'
 
-import Footer from '../components/common/Footer/index'
-import Header from '../components/common/Header/index'
-
 export default function Privacy() {
   return (
     <div className="min-w-full grid-cols-1 grid-rows-3">
@@ -14,7 +11,6 @@ export default function Privacy() {
           rel="stylesheet"
         />
       </Head>
-      <Header />
       <div className="m-96 my-16 font-sans">
         <h1>Privacy Policy</h1>
         <div>
@@ -242,7 +238,6 @@ export default function Privacy() {
           </p>
         </div>
       </div>
-      <Footer />
     </div>
   )
 }

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -1,9 +1,6 @@
 import Head from 'next/head'
 import React from 'react'
 
-import Footer from '../components/common/Footer/index'
-import Header from '../components/common/Header/index'
-
 export default function Terms() {
   return (
     <div className="min-w-full grid-cols-1 grid-rows-3">
@@ -14,7 +11,6 @@ export default function Terms() {
           rel="stylesheet"
         />
       </Head>
-      <Header />
       <div className="m-96 my-16 font-sans">
         <h1>Terms of Use</h1>
         <p>
@@ -420,7 +416,6 @@ export default function Terms() {
           connection therewith from the non- prevailing party.
         </p>
       </div>
-      <Footer />
     </div>
   )
 }


### PR DESCRIPTION
SS: 
![screencapture-localhost-3000-finance-actuals-2021-07-20-13_50_46](https://user-images.githubusercontent.com/52914487/126287314-b36d420f-6b95-4edc-9f6c-773949b232d6.png)
![screencapture-localhost-3000-finance-plan-2021-07-20-13_50_51](https://user-images.githubusercontent.com/52914487/126287323-a4637b7d-bd4b-40bb-95bb-11e71358083d.png)

Description of the change:
Fix double rendering of header, footer in terms and privacy page.
create a plan page
add switch to move between plan and actual page