### PR TITLE
feat(finance): add summary info

### DIFF
--- a/components/finance/FinanceCategories/index.tsx
+++ b/components/finance/FinanceCategories/index.tsx
@@ -7,6 +7,7 @@ import Loader from '../../common/Loader'
 import ExpensePanelDetails from '../ExpensePanelDetails'
 import FinanceCategoryList from '../FinanceCategoryList'
 import FinanceSpreadSheet from '../FinanceSpreadSheet'
+import SummaryInfo from '../SummaryInfo'
 
 type financeCategoriesProps = {
   columns: number
@@ -48,6 +49,15 @@ const FinanceCategories = ({ columns, activeCell, setActiveCell }: financeCatego
       },
     ],
   })
+
+  const [summaryModal, setSummaryModal] = useToggle(false)
+  const [workItemInfo, setWorkItemInfo] = useState('')
+
+  const summaryOnClick = (workitem: any) => {
+    setSummaryModal()
+    setWorkItemInfo(workitem)
+  }
+
   if (loading || error)
     return (
       <div>
@@ -74,7 +84,12 @@ const FinanceCategories = ({ columns, activeCell, setActiveCell }: financeCatego
         {workItems.map((item: any, rowIndex: any) => (
           <li key={item.id} className="h-12 flex mt-px">
             <div className="w-96 flex" onMouseOver={() => setActiveCell([rowIndex, activeColumn])}>
-              <FinanceCategoryList item={item} activeRow={activeRow} rowIndex={rowIndex} />
+              <FinanceCategoryList
+                item={item}
+                activeRow={activeRow}
+                rowIndex={rowIndex}
+                summaryOnClick={summaryOnClick}
+              />
             </div>
             <FinanceSpreadSheet
               columns={columns}
@@ -100,6 +115,7 @@ const FinanceCategories = ({ columns, activeCell, setActiveCell }: financeCatego
           />
         </div>
       ) : null}
+      {summaryModal ? <SummaryInfo setSummaryModal={setSummaryModal} workItemInfo={workItemInfo} /> : null}
     </div>
   )
 }

--- a/components/finance/FinanceCategoryList/index.tsx
+++ b/components/finance/FinanceCategoryList/index.tsx
@@ -5,7 +5,8 @@ function FinanceCategoryList({ item, rowIndex, activeRow, summaryOnClick }: any)
     <>
       <div
         onClick={() => summaryOnClick(item)}
-        onKeyDown={() => summaryOnClick(item)}
+        // onKeyDown={() => summaryOnClick(item)}
+        aria-hidden="true"
         role="button"
         tabIndex={0}
         className={`p-2.5 flex-1 cursor-pointer ${rowIndex === activeRow ? 'bg-workItemActive' : 'bg-workItem'}`}

--- a/components/finance/FinanceCategoryList/index.tsx
+++ b/components/finance/FinanceCategoryList/index.tsx
@@ -1,9 +1,17 @@
 import React from 'react'
 
-function FinanceCategoryList({ item, rowIndex, activeRow }: any) {
+function FinanceCategoryList({ item, rowIndex, activeRow, summaryOnClick }: any) {
   return (
     <>
-      <div className={`p-2.5 flex-1 ${rowIndex === activeRow ? 'bg-workItemActive' : 'bg-workItem'}`}>{item.name}</div>
+      <div
+        onClick={() => summaryOnClick(item)}
+        onKeyDown={() => summaryOnClick(item)}
+        role="button"
+        tabIndex={0}
+        className={`p-2.5 flex-1 cursor-pointer ${rowIndex === activeRow ? 'bg-workItemActive' : 'bg-workItem'}`}
+      >
+        {item.name}
+      </div>
       <div
         className={`p-2.5 w-24 text-center ${
           item.incomeOrExpense === 'expense' ? 'bg-plannedExpense' : 'bg-plannedIncome'

--- a/components/finance/SummaryInfo/SummaryInfo.stories.tsx
+++ b/components/finance/SummaryInfo/SummaryInfo.stories.tsx
@@ -1,12 +1,38 @@
-import React from 'react'
+import { ApolloProvider } from '@apollo/client'
+import React, { useEffect, useState } from 'react'
+import { useToggle } from 'react-use'
 
+import GetApolloClient from '../../../apis/apollo.client'
 import SummaryInfo from '.'
 
 export default {
   title: 'SummaryInfo',
   component: SummaryInfo,
 }
+const { worker } = require('../../../src/mocks/browser')
 
-const Template = () => <SummaryInfo />
+const Template = () => {
+  const [summaryModal] = useToggle(false)
+  const [workItemInfo] = useState('')
+  const [mockData, setMockData] = useState()
+
+  if (process.env.NODE_ENV === 'development') {
+    worker.start()
+  }
+
+  useEffect(() => {
+    fetch(`${process.env.WALLORA_BACKEND_WORKITEM_CURRENTMONTH}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setMockData(data)
+      })
+  }, [])
+
+  return (
+    <ApolloProvider client={GetApolloClient()}>
+      <SummaryInfo summaryModal={summaryModal} workItemInfo={workItemInfo} mockData={mockData} />
+    </ApolloProvider>
+  )
+}
 
 export const Default = Template.bind({})

--- a/components/finance/SummaryInfo/SummaryInfo.stories.tsx
+++ b/components/finance/SummaryInfo/SummaryInfo.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+import SummaryInfo from '.'
+
+export default {
+  title: 'SummaryInfo',
+  component: SummaryInfo,
+}
+
+const Template = () => <SummaryInfo />
+
+export const Default = Template.bind({})

--- a/components/finance/SummaryInfo/index.tsx
+++ b/components/finance/SummaryInfo/index.tsx
@@ -1,0 +1,161 @@
+import CloseIcon from '@material-ui/icons/Close'
+import React from 'react'
+
+export default function SummaryInfo({ setSummaryModal, workItemInfo }: any) {
+  return (
+    <div className="bg-summaryBackground h-screen w-screen flex justify-end items-center top-0 fixed z-50 ">
+      <div className="bg-summaryModalBackground right-4 absolute h-5/6 flex flex-col mr-5">
+        <div className="flex bg-secondary h-16 items-center justify-between">
+          <div className="pl-6">
+            <p className="text-xl m-0">WORKITEM DETAILS</p>
+          </div>
+          <div className="pr-4 cursor-pointer">
+            <CloseIcon onClick={setSummaryModal} fontSize="large" color="action" />
+          </div>
+        </div>
+
+        <p className="text-center font-bold my-2">{workItemInfo.name}</p>
+
+        <div className=" h-full overflow-auto">
+          <div className="flex pl-6 h-1/5">
+            <div>
+              <p className="leading-4 w-36 text-sm mt-1">Current Month:</p>
+            </div>
+            <div>
+              <ul className="list-none text-xs pl-0 mr-14 mt-0">
+                <li>Allocated Budget:</li>
+                <li>Actual Earned/Spent:</li>
+                <li>Remaining:</li>
+              </ul>
+            </div>
+            <div>
+              <ul className="list-none text-xs pl-0 mt-0">
+                <li>INR 7,000</li>
+                <li>INR 646</li>
+                <li>INR 6,354</li>
+              </ul>
+            </div>
+          </div>
+
+          <hr />
+
+          <div className="flex ml-6 h-44 ">
+            <div className="flex">
+              <p className="w-36 h-full mt-5 text-sm">Planned items:</p>
+            </div>
+            <div className="flex flex-col">
+              <div className="flex mt-5 text-xs">
+                <div>
+                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Date:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Amount:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Comment:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Tags:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Contacts:</p>
+                </div>
+              </div>
+              <div className="flex overflow-y-scroll">
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">
+                    <li>JUL 2021</li>
+                    <li>AUG 2021</li>
+                    <li>SEP 2021</li>
+                    <li>OCT 2021</li>
+                    <li>NOV 2021</li>
+                    <li>DEC 2021</li>
+                    <li>JAN 2022</li>
+                    <li>FEB 2022</li>
+                    <li>MAR 2022</li>
+                  </ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">{/* Amount */}</ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">{/* Comment */}</ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">{/* Tags */}</ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">{/* Contacts */}</ul>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <hr />
+
+          <div className="flex ml-6 h-44 ">
+            <div className="flex">
+              <p className="w-36 h-full mt-5 text-sm">Actual items:</p>
+            </div>
+            <div className="flex flex-col">
+              <div className="flex mt-5 text-xs">
+                <div>
+                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Date:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Amount:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Comment:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Tags:</p>
+                </div>
+                <div>
+                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Contacts:</p>
+                </div>
+              </div>
+              <div className="flex overflow-y-scroll">
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">
+                    <li>2/2 2021</li>
+                    <li>4/2 2021</li>
+                    <li>7/2 2021</li>
+                    <li>11/2 2021</li>
+                    <li>2/2 2021</li>
+                    <li>4/2 2021</li>
+                    <li>7/2 2021</li>
+                    <li>11/2 2021</li>
+                  </ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">
+                    <li>INR 120.00</li>
+                    <li>INR 230.00</li>
+                    <li>INR 547.00</li>
+                    <li>INR 120.00</li>
+                  </ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">
+                    <li>Egg Cheese</li>
+                    <li>Detergent</li>
+                    <li>Rice, Bread</li>
+                    <li>Cheese</li>
+                  </ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">{/* Tags */}</ul>
+                </div>
+                <div>
+                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">{/* Contacts */}</ul>
+                </div>
+              </div>
+            </div>
+          </div>
+          <hr />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/finance/SummaryInfo/index.tsx
+++ b/components/finance/SummaryInfo/index.tsx
@@ -1,9 +1,57 @@
+import { gql, useQuery } from '@apollo/client'
 import CloseIcon from '@material-ui/icons/Close'
 import React from 'react'
 
+import Loader from '../../common/Loader'
+
 export default function SummaryInfo({ setSummaryModal, workItemInfo }: any) {
+  const getCategories = () => gql`
+    query Chart {
+      charts {
+        currentMonth {
+          budget
+          spent
+        }
+        predictedSavings {
+          savings {
+            currencyCode
+          }
+        }
+        plannedItems {
+          date
+          amount
+          comment
+          tags
+          contact
+        }
+        actualItems {
+          date
+          amount
+          comment
+          tags
+          contact
+        }
+      }
+    }
+  `
+  const { loading, error, data } = useQuery(getCategories())
+
+  if (loading || error)
+    return (
+      <div>
+        <Loader open={loading} error={error} />
+      </div>
+    )
+
+  const currentMonth = data.charts.currentMonth[0]
+  const { currencyCode } = data.charts.predictedSavings[0].savings
+  const { plannedItems } = data.charts
+  const { actualItems } = data.charts
+
+  const actualItemsAmount = actualItems.map((item: any) => item.amount).reduce((a: number, b: number) => a + b)
+
   return (
-    <div className="bg-summaryBackground h-screen w-screen flex justify-end items-center top-0  z-50 ">
+    <div className="bg-summaryBackground h-screen w-screen flex justify-end items-center top-0 right-0 fixed z-50 ">
       <div className="bg-summaryModalBackground right-4 absolute h-5/6 flex flex-col mr-5">
         <div className="flex bg-secondary h-16 items-center justify-between">
           <div className="pl-6">
@@ -30,126 +78,79 @@ export default function SummaryInfo({ setSummaryModal, workItemInfo }: any) {
             </div>
             <div>
               <ul className="list-none text-xs pl-0 mt-0">
-                <li>INR 7,000</li>
-                <li>INR 646</li>
-                <li>INR 6,354</li>
+                <li>
+                  {currencyCode} {currentMonth.budget}
+                </li>
+                <li>
+                  {currencyCode} {actualItemsAmount}
+                </li>
+                <li>
+                  {currencyCode} {currentMonth.budget - actualItemsAmount}
+                </li>
               </ul>
             </div>
           </div>
-
           <hr />
-
           <div className="flex ml-6 h-44 ">
             <div className="flex">
               <p className="w-36 h-full mt-5 text-sm">Planned items:</p>
             </div>
             <div className="flex flex-col">
               <div className="flex mt-5 text-xs">
-                <div>
-                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Date:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Amount:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Comment:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Tags:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Contacts:</p>
-                </div>
+                <ul className="list-none m-0 p-0 flex ">
+                  <li className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Date:</li>
+                  <li className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Amount:</li>
+                  <li className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Comment:</li>
+                  <li className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Tags:</li>
+                  <li className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Contacts:</li>
+                </ul>
               </div>
-              <div className="flex overflow-y-scroll">
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">
-                    <li>JUL 2021</li>
-                    <li>AUG 2021</li>
-                    <li>SEP 2021</li>
-                    <li>OCT 2021</li>
-                    <li>NOV 2021</li>
-                    <li>DEC 2021</li>
-                    <li>JAN 2022</li>
-                    <li>FEB 2022</li>
-                    <li>MAR 2022</li>
-                  </ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">{/* Amount */}</ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">{/* Comment */}</ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">{/* Tags */}</ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">{/* Contacts */}</ul>
-                </div>
+              <div className="overflow-y-scroll h-44">
+                {plannedItems.map((item: any) => (
+                  <div className="flex text-xs">
+                    <ul className="list-none m-0 p-0 flex">
+                      <li className="leading-3 pl-0.5 w-28 py-2 m-0 mr-1">{item.date}</li>
+                      <li className="leading-3 pl-0.5 w-28 py-2 m-0 mr-1">
+                        {currencyCode} {item.amount}
+                      </li>
+                      <li className="leading-3 pl-0.5 w-40 py-2 m-0 mr-1">{item.comment}</li>
+                      <li className="leading-3 pl-0.5 w-40 py-2 m-0 mr-1">{item.tags}</li>
+                      <li className="leading-3 pl-0.5 w-28 py-2 m-0 mr-1">{item.contact}</li>
+                    </ul>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
-
           <hr />
-
           <div className="flex ml-6 h-44 ">
             <div className="flex">
               <p className="w-36 h-full mt-5 text-sm">Actual items:</p>
             </div>
             <div className="flex flex-col">
               <div className="flex mt-5 text-xs">
-                <div>
-                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Date:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Amount:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Comment:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Tags:</p>
-                </div>
-                <div>
-                  <p className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Contacts:</p>
-                </div>
+                <ul className="list-none m-0 p-0 flex ">
+                  <li className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Date:</li>
+                  <li className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Amount:</li>
+                  <li className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Comment:</li>
+                  <li className="leading-3 pl-0.5 w-40 bg-summaryItemTitle py-2 m-0 mr-1">Tags:</li>
+                  <li className="leading-3 pl-0.5 w-28 bg-summaryItemTitle py-2 m-0 mr-1">Contacts:</li>
+                </ul>
               </div>
-              <div className="flex overflow-y-scroll">
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">
-                    <li>2/2 2021</li>
-                    <li>4/2 2021</li>
-                    <li>7/2 2021</li>
-                    <li>11/2 2021</li>
-                    <li>2/2 2021</li>
-                    <li>4/2 2021</li>
-                    <li>7/2 2021</li>
-                    <li>11/2 2021</li>
-                  </ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">
-                    <li>INR 120.00</li>
-                    <li>INR 230.00</li>
-                    <li>INR 547.00</li>
-                    <li>INR 120.00</li>
-                  </ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">
-                    <li>Egg Cheese</li>
-                    <li>Detergent</li>
-                    <li>Rice, Bread</li>
-                    <li>Cheese</li>
-                  </ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-40 ml-0">{/* Tags */}</ul>
-                </div>
-                <div>
-                  <ul className="list-none text-xs pl-0 mr-1 mt-0 w-28 ml-0">{/* Contacts */}</ul>
-                </div>
+              <div className="overflow-y-scroll h-44">
+                {actualItems.map((item: any) => (
+                  <div className="flex text-xs">
+                    <ul className="list-none m-0 p-0 flex">
+                      <li className="leading-3 pl-0.5 w-28 py-2 m-0 mr-1">{item.date}</li>
+                      <li className="leading-3 pl-0.5 w-28 py-2 m-0 mr-1">
+                        {currencyCode} {item.amount}
+                      </li>
+                      <li className="leading-3 pl-0.5 w-40 py-2 m-0 mr-1">{item.comment}</li>
+                      <li className="leading-3 pl-0.5 w-40 py-2 m-0 mr-1">{item.tags}</li>
+                      <li className="leading-3 pl-0.5 w-28 py-2 m-0 mr-1">{item.contact}</li>
+                    </ul>
+                  </div>
+                ))}
               </div>
             </div>
           </div>

--- a/components/finance/SummaryInfo/index.tsx
+++ b/components/finance/SummaryInfo/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 export default function SummaryInfo({ setSummaryModal, workItemInfo }: any) {
   return (
-    <div className="bg-summaryBackground h-screen w-screen flex justify-end items-center top-0 fixed z-50 ">
+    <div className="bg-summaryBackground h-screen w-screen flex justify-end items-center top-0  z-50 ">
       <div className="bg-summaryModalBackground right-4 absolute h-5/6 flex flex-col mr-5">
         <div className="flex bg-secondary h-16 items-center justify-between">
           <div className="pl-6">

--- a/src/mocks/handlers.tsx
+++ b/src/mocks/handlers.tsx
@@ -12,6 +12,44 @@ export const handlers = [
       })
     )
   ),
+  rest.get(`${process.env.WALLORA_BACKEND_WORKITEM_CURRENTMONTH}`, (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.json({
+        month: 202107,
+        totalPlannedIncome: 150000,
+        totalPlannedExpenses: 42000,
+      })
+    )
+  ),
+  rest.get(`${process.env.WALLORA_BACKEND_WORKITEM_PLANNED_ITEMS}`, (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.json({
+        expenses: [
+          {
+            month: 202107,
+            totalPlannedIncome: 150000,
+            totalPlannedExpenses: 42000,
+          },
+        ],
+      })
+    )
+  ),
+  rest.get(`${process.env.WALLORA_BACKEND_WORKITEM_ACTUAL_ITEMS}`, (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.json({
+        expenses: [
+          {
+            month: 202107,
+            totalPlannedIncome: 150000,
+            totalPlannedExpenses: 42000,
+          },
+        ],
+      })
+    )
+  ),
   rest.get(`${process.env.WALLORA_BACKEND_TOTAL_PLANNED_EXPENSES_MONTHWISE}`, (req, res, ctx) =>
     res(
       ctx.status(200),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,9 @@ module.exports = {
         workItemActive: '#81816d',
         plannedIncome: 'rgba(97,255,42,.43)',
         plannedExpense: 'rgba(255,114,114,.49)',
+        summaryItemTitle: 'rgb(209,213,219)',
+        summaryModalBackground: 'rgb(255,255,255)',
+        summaryBackground: 'rgb(0,0,0,0.5)',
       },
       fontFamily: {
         sans: [


### PR DESCRIPTION
Fixes #110 
Screenshot: (if applicable):  
Description of the change:
- Add summary info modal.
- Add onClick in FinanceCategoryList/index.tsx to open summary info modal.
- Add summaryOnClick and setSummaryModal function in FinanceCategory/index.tsx to handle pop up summary modal .
- Values in summary modal currently mock numbers.