### PR TITLE
fix(auth) : swicth to auth0 for implementing routeguard 

### DIFF
--- a/components/common/BaseLayout/index.tsx
+++ b/components/common/BaseLayout/index.tsx
@@ -1,22 +1,14 @@
 import { useUser } from '@auth0/nextjs-auth0'
 import Head from 'next/head'
-import { useRouter } from 'next/router'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import Bottom from '../Bottom'
 import Loader from '../Loader'
 import Top from '../Top'
 
 function BaseLayout({ children }: any): React.ReactElement {
-  const router = useRouter()
   const { user, isLoading, error } = useUser()
 
-  useEffect(() => {
-    const protectedUrls = ['/finance', '/dashboard']
-    if (!user && protectedUrls.includes(router.pathname)) {
-      router.push('/api/auth/login')
-    }
-  }, [router, user])
   if (isLoading || error)
     return (
       <div>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,23 +1,17 @@
+import { withPageAuthRequired } from '@auth0/nextjs-auth0'
 import React from 'react'
 
-import BaseLayout from '../components/common/BaseLayout'
 import PlannedExpensesChart from '../components/dashboard/PlannedExpensesChart'
 import PredictedSavingsChart from '../components/dashboard/PredictedSavingsChart'
 import UserSettings from '../components/dashboard/UserSettings'
 import ClientSideRendering from '../lib/client-side-rendering'
 
-function DashBoard() {
-  return (
-    <ClientSideRendering>
-      <UserSettings />
-      <div className="ml-8">
-        <PredictedSavingsChart />
-        <PlannedExpensesChart />
-      </div>
-    </ClientSideRendering>
-  )
-}
-
-DashBoard.Layout = BaseLayout
-
-export default DashBoard
+export default withPageAuthRequired(() => (
+  <ClientSideRendering>
+    <UserSettings />
+    <div className="ml-8">
+      <PredictedSavingsChart />
+      <PlannedExpensesChart />
+    </div>
+  </ClientSideRendering>
+))

--- a/pages/finance/actuals.tsx
+++ b/pages/finance/actuals.tsx
@@ -1,7 +1,7 @@
+import { withPageAuthRequired } from '@auth0/nextjs-auth0'
 import { Button, makeStyles } from '@material-ui/core'
 import React, { useState } from 'react'
 
-import BaseLayout from '../../components/common/BaseLayout'
 import FinanceCategories from '../../components/finance/FinanceCategories'
 import FinanceDateHeader from '../../components/finance/FinanceDateHeader'
 import FinanceSwitch from '../../components/finance/FinanceSwitch'
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
   },
 })
 
-function Finance() {
+export default withPageAuthRequired(() => {
   const classes = useStyles()
   const marginLeft = 384
   const spreadSheetWidth = window.innerWidth - marginLeft
@@ -122,8 +122,4 @@ function Finance() {
       </div>
     </div>
   )
-}
-
-Finance.Layout = BaseLayout
-
-export default Finance
+})

--- a/pages/finance/plan.tsx
+++ b/pages/finance/plan.tsx
@@ -1,13 +1,10 @@
+import { withPageAuthRequired } from '@auth0/nextjs-auth0'
 import React from 'react'
 
 import FinanceSwitch from '../../components/finance/FinanceSwitch'
 
-function Plan() {
-  return (
-    <div className="grid grid-cols-financeHeader h-16">
-      <FinanceSwitch actualOrPlan="Plan" />
-    </div>
-  )
-}
-
-export default Plan
+export default withPageAuthRequired(() => (
+  <div className="grid grid-cols-financeHeader h-16">
+    <FinanceSwitch actualOrPlan="Plan" />
+  </div>
+))


### PR DESCRIPTION
This change will remove previous added next.js router to handle redirect to login , If a user tries to navigate to protected url's unauthorised.
It is unecessary as auth0 Itself can handle It.
[protecting-a-client-side-rendered-csr-page](https://github.com/auth0/nextjs-auth0/blob/main/EXAMPLES.md#protecting-a-client-side-rendered-csr-page)